### PR TITLE
Fix Tinkers Hatchet

### DIFF
--- a/java/lycanite/lycanitesmobs/api/info/ObjectLists.java
+++ b/java/lycanite/lycanitesmobs/api/info/ObjectLists.java
@@ -340,7 +340,7 @@ public class ObjectLists {
             for(String toolNamePart : toolNameParts)
             if(toolNameParts.length >= 3 && "InfiTool".equalsIgnoreCase(toolNameParts[1])) {
                 String toolName = toolNameParts[2];
-                if("Hatchet".equalsIgnoreCase(toolName) || "LumberAxe".equalsIgnoreCase(toolName) || "Mattock".equalsIgnoreCase(toolName) || "Battleaxe".equalsIgnoreCase(toolName))
+                if("Axe".equalsIgnoreCase(toolName) || "LumberAxe".equalsIgnoreCase(toolName) || "Mattock".equalsIgnoreCase(toolName) || "Battleaxe".equalsIgnoreCase(toolName))
                     return true;
                 return false;
             }


### PR DESCRIPTION
For some reason the Tinkers "Hatchet" uses "Axe" rather than "Hatchet" in it's Unlocalized Name. all other tinkers tools that I've tested are working.