### PR TITLE
Typo

### DIFF
--- a/src/main/resources/assets/plainsmobs/sounds.json
+++ b/src/main/resources/assets/plainsmobs/sounds.json
@@ -247,9 +247,9 @@
         "category": "hostile",
         "sounds": [{"name": "plainsmobs:entity/quillbeast/eat", "stream": false}]
     },
-    "entity.roc.say": {
+    "entity.morock.say": {
         "category": "hostile",
-        "sounds": [{"name": "plainsmobs:entity/roc/say", "stream": false}]
+        "sounds": [{"name": "plainsmobs:entity/morock/say", "stream": false}]
     },
     "entity.morock.hurt": {
         "category": "hostile",


### PR DESCRIPTION
I think you meant to type "Morock" instead of "Roc" for that one. I know it's minor; it just bothered me a bit.