### PR TITLE
fix summoning staff not being damaged or removed when broken

### DIFF
--- a/src/main/java/com/lycanitesmobs/core/entity/EntityPortal.java
+++ b/src/main/java/com/lycanitesmobs/core/entity/EntityPortal.java
@@ -187,11 +187,11 @@ public class EntityPortal extends EntityProjectileBase {
     // ==================================================
   	//                 Summon Creatures
   	// ==================================================
-    public boolean summonCreatures() {
+    public int summonCreatures() {
     	if(this.getEntityWorld().isRemote)
-    		return true;
+    		return 1;
         if(this.summonClass == null)
-            return false;
+            return 0;
     	for(int i = 0; i < this.summonAmount; i++) {
 	    	Entity entity = null;
 			try {
@@ -201,7 +201,7 @@ public class EntityPortal extends EntityProjectileBase {
 				e.printStackTrace();
 			}
 	    	if(entity == null)
-	    		return false;
+	    		return 0;
 	    	entity.setLocationAndAngles(this.posX, this.posY, this.posZ, this.rand.nextFloat() * 360.0F, 0.0F);
 	    	if(entity instanceof EntityCreatureBase) {
                 EntityCreatureBase entityCreature = (EntityCreatureBase) entity;
@@ -235,9 +235,9 @@ public class EntityPortal extends EntityProjectileBase {
             }
 	    	this.getEntityWorld().spawnEntity(entity);
     	}
-    	boolean summonedCreatures = this.summonAmount > 0;
+        int amount = this.summonAmount;
     	this.summonAmount = 0;
-    	return summonedCreatures;
+    	return amount;
     }
 	
     

--- a/src/main/java/com/lycanitesmobs/core/item/ItemStaffSummoning.java
+++ b/src/main/java/com/lycanitesmobs/core/item/ItemStaffSummoning.java
@@ -55,7 +55,7 @@ public class ItemStaffSummoning extends ItemScepter {
     
     public void damageItemCharged(ItemStack itemStack, EntityLivingBase entity, float power) {
     	if(this.portalEntity != null) {
-    		itemStack.damageItem(this.portalEntity.summonAmount, entity);
+            this.damage_item(itemStack, this.portalEntity.summonAmount, entity);
     	}
     }
     
@@ -146,14 +146,26 @@ public class ItemStaffSummoning extends ItemScepter {
     public boolean rapidAttack(ItemStack itemStack, World world, EntityLivingBase entity) {
     	return false;
     }
+
+    private void damage_item(ItemStack itemStack, int amountToDamage, EntityLivingBase entity)
+    {
+        itemStack.damageItem(amountToDamage, entity);
+        if (itemStack.getCount() == 0) {
+            if (entity.getHeldItem(EnumHand.MAIN_HAND).equals(itemStack)) {
+                entity.setHeldItem(EnumHand.MAIN_HAND, ItemStack.EMPTY);
+            } else if (entity.getHeldItem(EnumHand.OFF_HAND).equals(itemStack)) {
+                entity.setHeldItem(EnumHand.OFF_HAND, ItemStack.EMPTY);
+            }
+        }
+    }
     
     // ========== Charged ==========
     @Override
     public boolean chargedAttack(ItemStack itemStack, World world, EntityLivingBase entity, float power) {
     	if(this.portalEntity != null) {
-			boolean success = this.portalEntity.summonCreatures();
-			this.portalEntity = null;
-			return success;
+			int successCount = this.portalEntity.summonCreatures();
+            this.damage_item(itemStack, successCount, entity);
+			return successCount > 0;
 		}
 		return false;
     }


### PR DESCRIPTION
Here is the fix I've been using for #383 doesn't address the fact that portal entity isn't properly handled but does work around it. In practice the only time an issue occurs at the moment is in the rare case when 2 players are trying to summon the same thing.